### PR TITLE
fix: time offset decoupling and sync resilience

### DIFF
--- a/.hooks/check_arduino.py
+++ b/.hooks/check_arduino.py
@@ -63,12 +63,12 @@ if any(f.startswith("src/") for f in staged):
             break
 
 
-# 4. NTP epoch constant must remain in EasyNTPClient.cpp
-if "src/EasyNTPClient.cpp" in staged:
-    content = staged_content("src/EasyNTPClient.cpp") or ""
+# 4. NTP epoch offset must be defined in EasyNTPClient.h
+if "src/EasyNTPClient.h" in staged:
+    content = staged_content("src/EasyNTPClient.h") or ""
     if "2208988800" not in content:
         errors.append(
-            "NTP epoch constant (2208988800UL) removed from src/EasyNTPClient.cpp"
+            "NTP_UNIX_EPOCH_OFFSET (2208988800UL) removed from src/EasyNTPClient.h"
         )
 
 

--- a/examples/TestNodeMCU/TestNodeMCU.ino
+++ b/examples/TestNodeMCU/TestNodeMCU.ino
@@ -89,6 +89,58 @@ void test_client_reuse() {
   check(t2 >= t1 && (t2 - t1) < 5, "timestamps consistent between clients");
 }
 
+// ── offset decoupling ────────────────────────────────────────────────────────
+
+void test_offset_immediate() {
+  Serial.println("\n-- offset change takes effect without resync --");
+  WiFiUDP udp;
+  EasyNTPClient client(udp, "pool.ntp.org");
+
+  // Sync once with offset = 0; capture base time.
+  client.setTimeOffset(0);
+  unsigned long base = client.getUnixTime();
+  check(base > MIN_UNIX_2024, "initial sync with offset=0 succeeds");
+
+  // Change offset without waiting for a resync (mUpdateInterval not elapsed).
+  client.setTimeOffset(3600);
+  unsigned long adjusted = client.getUnixTime();
+  long delta = (long)adjusted - (long)base;
+  check(delta >= 3598 && delta <= 3602, "+3600 s offset reflected on next call");
+
+  // Reverse to zero.
+  client.setTimeOffset(0);
+  unsigned long restored = client.getUnixTime();
+  delta = (long)restored - (long)base;
+  check(delta >= 0 && delta <= 2, "offset=0 reflected immediately after reversal");
+}
+
+// ── stale time preservation ──────────────────────────────────────────────────
+
+void test_stale_time() {
+  Serial.println("\n-- stale time preserved when resync fails (wait ~70 s) --");
+  WiFiUDP udp;
+  EasyNTPClient client(udp, "pool.ntp.org");
+
+  // Populate mServerTime with a good sync.
+  unsigned long good = client.getUnixTime();
+  check(good > MIN_UNIX_2024, "initial sync succeeds before WiFi drop");
+
+  // Drop WiFi and wait for mUpdateInterval (60 s default) to expire so the
+  // next getUnixTime() call attempts a resync, fails, and should return the
+  // preserved mServerTime + millis() drift.
+  WiFi.disconnect();
+  Serial.println("   WiFi disconnected. Waiting 65 s...");
+  delay(65000);
+
+  unsigned long stale = client.getUnixTime();
+  long drift = (long)stale - (long)good;
+  // Allow 63-72 s: 65 s delay plus up to 7 s for sync timeout polling.
+  check(drift >= 63 && drift <= 72, "stale time preserved and advancing during no-WiFi");
+
+  // Reconnect before the next test group.
+  wifi_connect();
+}
+
 // ── entry points ─────────────────────────────────────────────────────────────
 
 void setup() {
@@ -101,6 +153,8 @@ void setup() {
   test_constants();
   test_basic_sync();
   test_client_reuse();
+  test_offset_immediate();
+  test_stale_time();
 
   Serial.println("\n=== Results ===");
   Serial.print(g_passed); Serial.println(" passed");

--- a/src/EasyNTPClient.cpp
+++ b/src/EasyNTPClient.cpp
@@ -104,11 +104,13 @@ unsigned long EasyNTPClient::getServerTime () {
 }
 
 unsigned long EasyNTPClient::getUnixTime() {
-  // if (this->mServerTime < 0) {
   unsigned long delta = millis() - this->mLastUpdate;
   if (this->mServerTime <= 0 || this->mLastUpdate == 0 || delta >= this->mUpdateInterval) {
-    this->mServerTime = this->getServerTime();
-    this->mLastUpdate = millis();
+    unsigned long fetched = this->getServerTime();
+    if (fetched > 0) {
+      this->mServerTime = fetched;
+      this->mLastUpdate = millis();
+    }
   }
   return this->mServerTime + ((millis() - this->mLastUpdate) / 1000) + this->mOffset;
 }

--- a/src/EasyNTPClient.cpp
+++ b/src/EasyNTPClient.cpp
@@ -100,7 +100,7 @@ unsigned long EasyNTPClient::getServerTime () {
     this->mUdp->flush();
     this->mUdp->stop();
 
-    return time + this->mOffset - 2208988800ul;   // convert NTP time to Unix time
+    return time - NTP_UNIX_EPOCH_OFFSET;
 }
 
 unsigned long EasyNTPClient::getUnixTime() {
@@ -110,5 +110,5 @@ unsigned long EasyNTPClient::getUnixTime() {
     this->mServerTime = this->getServerTime();
     this->mLastUpdate = millis();
   }
-  return this->mServerTime + ((millis() - this->mLastUpdate) / 1000);
+  return this->mServerTime + ((millis() - this->mLastUpdate) / 1000) + this->mOffset;
 }

--- a/src/EasyNTPClient.h
+++ b/src/EasyNTPClient.h
@@ -28,6 +28,11 @@
 #define NTP_HEADER_POLL         6           // poll interval as log2 seconds (2^6 = 64 s)
 #define NTP_HEADER_PRECISION    0xEC        // system clock precision in log2 seconds
 
+// Seconds between the NTP epoch (1900-01-01) and the Unix epoch (1970-01-01).
+// NTP timestamps are based on 1900; Unix timestamps on 1970. Subtracting this
+// constant converts a raw NTP timestamp to a Unix timestamp.
+#define NTP_UNIX_EPOCH_OFFSET   2208988800ul
+
 class EasyNTPClient
 {
   public:


### PR DESCRIPTION
## Summary

- **Decouple time offset from cached server time**:
  - `getServerTime()` previously baked `mOffset` into its return value, which was then cached in `mServerTime`.
  - Calling `setTimeOffset()` after the first sync had no effect until the next NTP resync.
  - The offset is now applied exclusively in `getUnixTime()`, so `setTimeOffset()` takes effect on the very next call without waiting for a resync.

- **Preserve last known time on failed sync**:
  - `getUnixTime()` previously overwrote `mServerTime` with `0` on a failed resync, causing the function to return `0` until connectivity was restored.
  - `mServerTime` and `mLastUpdate` are now only updated when `getServerTime()` returns a valid (non-zero) timestamp, so the last good time continues to advance via `millis()` drift during outages.

- **Add `NTP_UNIX_EPOCH_OFFSET`**:
  - The magic constant `2208988800UL` (seconds between the NTP epoch 1900-01-01 and the Unix epoch 1970-01-01) is now a named `#define` in the header with an explanatory comment.
  - The pre-commit hook guarding this constant has been updated to check the header instead of the `.cpp`.

- Adds `test_offset_immediate()` and `test_stale_time()` to `examples/TestNodeMCU/TestNodeMCU.ino`.

**Note:** `test_stale_time` disconnects WiFi and waits ~70 s before reconnecting.

Closes #2