### PR TITLE
feat: runtime-configurable update interval and NTP server switching

### DIFF
--- a/examples/TestNodeMCU/TestNodeMCU.ino
+++ b/examples/TestNodeMCU/TestNodeMCU.ino
@@ -127,6 +127,24 @@ void test_was_updated() {
   check(client.wasUpdated(), "wasUpdated() is true after successful sync");
 }
 
+// ── NTP server get/set ───────────────────────────────────────────────────────
+
+void test_set_ntp_server() {
+  Serial.println("\n-- setNTPServer() / getNTPServer() --");
+  WiFiUDP udp;
+  EasyNTPClient client(udp, "pool.ntp.org");
+
+  check(strcmp(client.getNTPServer(), "pool.ntp.org") == 0,
+        "getNTPServer() returns initial pool");
+
+  client.setNTPServer("time.cloudflare.com");
+  check(strcmp(client.getNTPServer(), "time.cloudflare.com") == 0,
+        "getNTPServer() reflects setNTPServer()");
+
+  unsigned long t = client.getUnixTime();
+  check(t > MIN_UNIX_2024, "syncs from server set via setNTPServer()");
+}
+
 // ── stale time preservation ──────────────────────────────────────────────────
 
 void test_stale_time() {
@@ -168,6 +186,7 @@ void setup() {
   test_client_reuse();
   test_offset_immediate();
   test_was_updated();
+  test_set_ntp_server();
   test_stale_time();
 
   Serial.println("\n=== Results ===");

--- a/examples/TestNodeMCU/TestNodeMCU.ino
+++ b/examples/TestNodeMCU/TestNodeMCU.ino
@@ -145,6 +145,23 @@ void test_set_ntp_server() {
   check(t > MIN_UNIX_2024, "syncs from server set via setNTPServer()");
 }
 
+// ── update interval get/set ───────────────────────────────────────────────────
+
+void test_set_update_interval() {
+  Serial.println("\n-- setUpdateInterval() / getUpdateInterval() / 4-arg constructor --");
+  WiFiUDP udp;
+
+  EasyNTPClient client(udp, "pool.ntp.org");
+  client.setUpdateInterval(30);
+  check(client.getUpdateInterval() == 30, "getUpdateInterval() reflects setUpdateInterval(30 s)");
+
+  EasyNTPClient client2(udp, "pool.ntp.org", 0, 120);
+  check(client2.getUpdateInterval() == 120, "4-arg constructor sets update interval to 120 s");
+
+  unsigned long t = client2.getUnixTime();
+  check(t > MIN_UNIX_2024, "syncs with interval set via 4-arg constructor");
+}
+
 // ── stale time preservation ──────────────────────────────────────────────────
 
 void test_stale_time() {
@@ -187,6 +204,7 @@ void setup() {
   test_offset_immediate();
   test_was_updated();
   test_set_ntp_server();
+  test_set_update_interval();
   test_stale_time();
 
   Serial.println("\n=== Results ===");

--- a/examples/TestNodeMCU/TestNodeMCU.ino
+++ b/examples/TestNodeMCU/TestNodeMCU.ino
@@ -114,6 +114,19 @@ void test_offset_immediate() {
   check(delta >= 0 && delta <= 2, "offset=0 reflected immediately after reversal");
 }
 
+// ── wasUpdated flag ──────────────────────────────────────────────────────────
+
+void test_was_updated() {
+  Serial.println("\n-- wasUpdated() flag --");
+  WiFiUDP udp;
+  EasyNTPClient client(udp, "pool.ntp.org");
+
+  check(!client.wasUpdated(), "wasUpdated() is false before first sync");
+
+  client.getUnixTime();
+  check(client.wasUpdated(), "wasUpdated() is true after successful sync");
+}
+
 // ── stale time preservation ──────────────────────────────────────────────────
 
 void test_stale_time() {
@@ -154,6 +167,7 @@ void setup() {
   test_basic_sync();
   test_client_reuse();
   test_offset_immediate();
+  test_was_updated();
   test_stale_time();
 
   Serial.println("\n=== Results ===");

--- a/src/EasyNTPClient.cpp
+++ b/src/EasyNTPClient.cpp
@@ -42,6 +42,14 @@ bool EasyNTPClient::wasUpdated() {
   return this->mWasUpdated;
 }
 
+const char* EasyNTPClient::getNTPServer() {
+  return this->mServerPool;
+}
+
+void EasyNTPClient::setNTPServer(const char* serverPool) {
+  this->mServerPool = serverPool;
+}
+
 
 unsigned long EasyNTPClient::getServerTime () {
     int udpInited = this->mUdp->begin(NTP_REQUEST_PORT);

--- a/src/EasyNTPClient.cpp
+++ b/src/EasyNTPClient.cpp
@@ -30,6 +30,13 @@ EasyNTPClient::EasyNTPClient (UDP &udp, const char* serverPool, int offset) {
   this->mOffset = offset;
 }
 
+EasyNTPClient::EasyNTPClient (UDP &udp, const char* serverPool, int offset, uint32_t updateIntervalSecs) {
+  this->mUdp = &udp;
+  this->mServerPool = serverPool;
+  this->mOffset = offset;
+  this->mUpdateInterval = updateIntervalSecs * 1000;
+}
+
 int EasyNTPClient::getTimeOffset() {
   return this->mOffset;
 }
@@ -48,6 +55,14 @@ const char* EasyNTPClient::getNTPServer() {
 
 void EasyNTPClient::setNTPServer(const char* serverPool) {
   this->mServerPool = serverPool;
+}
+
+uint32_t EasyNTPClient::getUpdateInterval() {
+  return this->mUpdateInterval / 1000;
+}
+
+void EasyNTPClient::setUpdateInterval(uint32_t seconds) {
+  this->mUpdateInterval = seconds * 1000;
 }
 
 

--- a/src/EasyNTPClient.cpp
+++ b/src/EasyNTPClient.cpp
@@ -38,6 +38,10 @@ void EasyNTPClient::setTimeOffset (int offset) {
   this->mOffset = offset;
 }
 
+bool EasyNTPClient::wasUpdated() {
+  return this->mWasUpdated;
+}
+
 
 unsigned long EasyNTPClient::getServerTime () {
     int udpInited = this->mUdp->begin(NTP_REQUEST_PORT);
@@ -110,6 +114,9 @@ unsigned long EasyNTPClient::getUnixTime() {
     if (fetched > 0) {
       this->mServerTime = fetched;
       this->mLastUpdate = millis();
+      this->mWasUpdated = true;
+    } else {
+      this->mWasUpdated = false;
     }
   }
   return this->mServerTime + ((millis() - this->mLastUpdate) / 1000) + this->mOffset;

--- a/src/EasyNTPClient.h
+++ b/src/EasyNTPClient.h
@@ -39,10 +39,13 @@ class EasyNTPClient
     EasyNTPClient(UDP &udp);
     EasyNTPClient(UDP& udp, const char* serverPool);
     EasyNTPClient(UDP& udp, const char* serverPool, int offset);
+    EasyNTPClient(UDP& udp, const char* serverPool, int offset, uint32_t updateIntervalSecs);
     int getTimeOffset();
     void setTimeOffset(int offset);
     const char* getNTPServer();
     void setNTPServer(const char* serverPool);
+    uint32_t getUpdateInterval();
+    void setUpdateInterval(uint32_t seconds);
     unsigned long getUnixTime();
     bool wasUpdated();
 

--- a/src/EasyNTPClient.h
+++ b/src/EasyNTPClient.h
@@ -41,6 +41,8 @@ class EasyNTPClient
     EasyNTPClient(UDP& udp, const char* serverPool, int offset);
     int getTimeOffset();
     void setTimeOffset(int offset);
+    const char* getNTPServer();
+    void setNTPServer(const char* serverPool);
     unsigned long getUnixTime();
     bool wasUpdated();
 

--- a/src/EasyNTPClient.h
+++ b/src/EasyNTPClient.h
@@ -42,6 +42,7 @@ class EasyNTPClient
     int getTimeOffset();
     void setTimeOffset(int offset);
     unsigned long getUnixTime();
+    bool wasUpdated();
 
   private:
     UDP *mUdp;
@@ -50,6 +51,7 @@ class EasyNTPClient
     uint32_t mUpdateInterval = 60000;
     unsigned long mLastUpdate = 0;
     long mServerTime = 0;
+    bool mWasUpdated = false;
     unsigned long getServerTime();
 };
 


### PR DESCRIPTION
Update API to give callers runtime control over sync behaviour and observability.

### Changes

**`wasUpdated()`**:
- `bool wasUpdated()` returns `true` if the most recent `getUnixTime()` call triggered a successful NTP resync;  
   `false` if it failed or no resync was attempted yet.
- Private `bool mWasUpdated` tracks the flag across calls.

**`getNTPServer()` / `setNTPServer()`**:
- `const char* getNTPServer()` returns the active server pool string.
- `void setNTPServer(const char* serverPool)` switches the pool at runtime without constructing a new client.

**`getUpdateInterval()` / `setUpdateInterval()` / 4-arg constructor**
- `uint32_t getUpdateInterval()` returns the current resync interval in  **seconds**.
- `void setUpdateInterval(uint32_t seconds)` changes it at runtime;  
   stores milliseconds internally for `millis()` comparison.
- New 4-arg constructor: `EasyNTPClient(UDP&, const char* pool, int offset, uint32_t intervalSecs)`

**Test sketch** (`examples/TestNodeMCU/TestNodeMCU.ino`)
- `test_was_updated()`: verifies flag is `false` before first sync, `true` after a successful sync.
- `test_set_ntp_server()`: verifies getter round-trips the default pool, reflects `setNTPServer()`, and syncs from the new server.
- `test_set_update_interval()`: verifies getter reflects setter and the 4-arg constructor, then confirms sync works with a custom interval.