### PR TITLE
ci: add ESP32 simulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  # pull_request:
   workflow_dispatch:
 
 jobs:
@@ -117,8 +117,8 @@ jobs:
           cli-compile-flags: |
             - --export-binaries
 
-      - name: Tree the compiled sketch
-        run: tree -L 5 build/
+      - name: Tree sketch directory
+        run: tree -L 5 examples/TestNTPClient/
 
       - name: Simulate with Wokwi
         uses: wokwi/wokwi-ci-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
             - name: WiFiEsp
           cli-compile-flags: |
             - --export-binaries
-            - --output-dir ${{ github.workspace }}/build
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -117,7 +116,9 @@ jobs:
             - name: WiFiEsp
           cli-compile-flags: |
             - --export-binaries
-            - --output-dir ${{ github.workspace }}/examples/TestNTPClient/build
+
+      - name: Tree the compiled sketch
+        run: tree -L 5 build/
 
       - name: Simulate with Wokwi
         uses: wokwi/wokwi-ci-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  # pull_request:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,19 +126,25 @@ jobs:
       - name: Tree sketch directory
         run: tree -L 5 examples/TestNTPClient/
 
-      - name: Simulate with Wokwi
-        uses: wokwi/wokwi-ci-action@v1
-        with:
-          token: ${{ secrets.WOKWI_TOKEN }}
-          path: examples/TestNTPClient
-          timeout: 300000
-          expect_text: "0 failed"
-          fail_text: "[FAIL]"
-          serial_log_file: wokwi-serial.log
-
-      - name: Upload serial log on failure
-        if: failure()
+      - name: Upload compiled binary
         uses: actions/upload-artifact@v4
         with:
-          name: wokwi-serial-log
-          path: wokwi-serial.log
+          name: testntp-esp32-bin
+          path: examples/TestNTPClient/
+
+      # - name: Simulate with Wokwi
+      #   uses: wokwi/wokwi-ci-action@v1
+      #   with:
+      #     token: ${{ secrets.WOKWI_TOKEN }}
+      #     path: examples/TestNTPClient
+      #     timeout: 300000
+      #     expect_text: "0 failed"
+      #     fail_text: "[FAIL]"
+      #     serial_log_file: wokwi-serial.log
+
+      # - name: Upload serial log on failure
+      #   if: failure()
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: wokwi-serial-log
+      #     path: wokwi-serial.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,29 +32,27 @@ jobs:
             platforms: |
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
-          - name: TestNTPClient (ESP32)
-            fqbn: esp32:esp32:esp32
-            sketch: examples/TestNTPClient/TestNTPClient.ino
-            platforms: |
-              - name: esp32:esp32
-                source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+            artifact_name: testntp-esp8266
           - name: TestNTPClient (Uno+ESP-01)
             fqbn: arduino:avr:uno
             sketch: examples/TestNTPClient/TestNTPClient.ino
             platforms: |
               - name: arduino:avr
+            artifact_name: testntp-uno
           # examples
-          - name: NodeMCU (ESP8266)
+          - name: Example - NodeMCU (ESP8266)
             fqbn: esp8266:esp8266:nodemcuv2
             sketch: examples/NodeMCU/NodeMCU.ino
             platforms: |
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
-          - name: Arduino UNO
+            artifact_name: example-nodemcu-esp8266
+          - name: Example - Arduino UNO + ESP-01
             fqbn: arduino:avr:uno
             sketch: examples/ArduinoEspWifiShield/ArduinoEspWifiShield.ino
             platforms: |
               - name: arduino:avr
+            artifact_name: example-arduinouno
 
     steps:
       - uses: actions/checkout@v6
@@ -79,3 +77,61 @@ jobs:
           libraries: |
             - source-path: ./
             - name: WiFiEsp
+          cli-compile-flags: |
+            - --export-binaries
+            - --output-dir ${{ github.workspace }}/build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.config.artifact_name }}
+          path: build/
+
+  simulate:
+    name: Simulate / TestNTPClient (ESP32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Arduino platforms and libraries
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.arduino15/packages
+            ~/Arduino/libraries
+          key: ${{ runner.os }}-arduino-esp32:esp32:esp32-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-arduino-esp32:esp32:esp32-
+
+      - name: Compile sketch
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: esp32:esp32:esp32
+          platforms: |
+            - name: esp32:esp32
+              source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+          sketch-paths: |
+            - examples/TestNTPClient/TestNTPClient.ino
+          libraries: |
+            - source-path: ./
+            - name: WiFiEsp
+          cli-compile-flags: |
+            - --export-binaries
+            - --output-dir ${{ github.workspace }}/examples/TestNTPClient/build
+
+      - name: Simulate with Wokwi
+        uses: wokwi/wokwi-ci-action@v1
+        with:
+          token: ${{ secrets.WOKWI_TOKEN }}
+          path: examples/TestNTPClient
+          timeout: 150000
+          expect_text: "0 failed"
+          fail_text: "[FAIL]"
+          serial_log_file: wokwi-serial.log
+
+      - name: Upload serial log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wokwi-serial-log
+          path: wokwi-serial.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           # TestNTPClient
           - name: TestNTPClient (ESP8266)
             fqbn: esp8266:esp8266:nodemcuv2
+            sketch_dir: examples/TestNTPClient
             sketch: examples/TestNTPClient/TestNTPClient.ino
             platforms: |
               - name: esp8266:esp8266
@@ -35,6 +36,7 @@ jobs:
             artifact_name: testntp-esp8266
           - name: TestNTPClient (Uno+ESP-01)
             fqbn: arduino:avr:uno
+            sketch_dir: examples/TestNTPClient
             sketch: examples/TestNTPClient/TestNTPClient.ino
             platforms: |
               - name: arduino:avr
@@ -42,6 +44,7 @@ jobs:
           # examples
           - name: Example - NodeMCU (ESP8266)
             fqbn: esp8266:esp8266:nodemcuv2
+            sketch_dir: examples/NodeMCU
             sketch: examples/NodeMCU/NodeMCU.ino
             platforms: |
               - name: esp8266:esp8266
@@ -49,6 +52,7 @@ jobs:
             artifact_name: example-nodemcu-esp8266
           - name: Example - Arduino UNO + ESP-01
             fqbn: arduino:avr:uno
+            sketch_dir: examples/ArduinoEspWifiShield
             sketch: examples/ArduinoEspWifiShield/ArduinoEspWifiShield.ino
             platforms: |
               - name: arduino:avr
@@ -80,11 +84,8 @@ jobs:
           cli-compile-flags: |
             - --export-binaries
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.config.artifact_name }}
-          path: build/
+      - name: Tree sketch directory
+        run: tree -L 5 ${{ matrix.config.sketch_dir }}
 
   simulate:
     name: Simulate / TestNTPClient (ESP32)
@@ -101,6 +102,11 @@ jobs:
           key: ${{ runner.os }}-arduino-esp32:esp32:esp32-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: |
             ${{ runner.os }}-arduino-esp32:esp32:esp32-
+
+      - name: Patch WiFi credentials for Wokwi
+        run: |
+          sed -i -E 's/(WIFI_SSID\s*=\s*)"[^"]*"/\1"Wokwi-GUEST"/' examples/TestNTPClient/TestNTPClient.ino
+          sed -i -E 's/(WIFI_PASSWORD\s*=\s*)"[^"]*"/\1""/' examples/TestNTPClient/TestNTPClient.ino
 
       - name: Compile sketch
         uses: arduino/compile-sketches@v1
@@ -125,7 +131,7 @@ jobs:
         with:
           token: ${{ secrets.WOKWI_TOKEN }}
           path: examples/TestNTPClient
-          timeout: 150000
+          timeout: 300000
           expect_text: "0 failed"
           fail_text: "[FAIL]"
           serial_log_file: wokwi-serial.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,19 +132,15 @@ jobs:
           name: testntp-esp32-bin
           path: examples/TestNTPClient/
 
-      # - name: Simulate with Wokwi
-      #   uses: wokwi/wokwi-ci-action@v1
-      #   with:
-      #     token: ${{ secrets.WOKWI_TOKEN }}
-      #     path: examples/TestNTPClient
-      #     timeout: 300000
-      #     expect_text: "0 failed"
-      #     fail_text: "[FAIL]"
-      #     serial_log_file: wokwi-serial.log
+      - name: Simulate with Wokwi
+        uses: wokwi/wokwi-ci-action@v1
+        with:
+          token: ${{ secrets.WOKWI_TOKEN }}
+          path: examples/TestNTPClient
+          timeout: 300000
+          expect_text: "0 failed"
+          fail_text: "[FAIL]"
+          serial_log_file: wokwi-serial.log
 
-      # - name: Upload serial log on failure
-      #   if: failure()
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: wokwi-serial-log
-      #     path: wokwi-serial.log
+      - name: Cat serial log
+        run: cat wokwi-serial.log

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  # pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/examples/**/build/

--- a/examples/TestNTPClient/TestNTPClient.ino
+++ b/examples/TestNTPClient/TestNTPClient.ino
@@ -230,6 +230,23 @@ void test_stale_time() {
   Serial.print(g_failed - _f); Serial.println(F(" failed")); \
 } while (0)
 
+#if defined(ESP32)
+void setupEsp32Watchdog() {
+  // 30 s — long enough for slow NTP in Wokwi simulation; still catches infinite loops.
+  esp_task_wdt_config_t twdt_config = {
+      .timeout_ms = 30000,
+      .idle_core_mask = 0,
+      .trigger_panic = true
+  };
+  // Arduino framework may have already initialized TWDT with a 5 s timeout.
+  // esp_task_wdt_init() fails in that case, so use reconfigure() first.
+  if (esp_task_wdt_reconfigure(&twdt_config) != ESP_OK)
+    esp_task_wdt_init(&twdt_config);
+  // ESP_ERR_INVALID_ARG means already subscribed by the framework — still fine.
+  esp_task_wdt_add(NULL);
+}
+#endif
+
 void setup() {
   Serial.begin(115200);
   delay(100);
@@ -238,6 +255,11 @@ void setup() {
 #if !defined(ESP8266) && !defined(ESP32)
   esp_serial.begin(9600);
   WiFi.init(&esp_serial);
+#endif
+
+#if defined(ESP32)
+  setupEsp32Watchdog();
+  Serial.println(F("ESP32 watchdog timer configured (30 s timeout)"));
 #endif
 
   wifi_connect();

--- a/examples/TestNTPClient/diagram.json
+++ b/examples/TestNTPClient/diagram.json
@@ -5,12 +5,25 @@
   "parts": [
     {
       "type": "board-esp32-devkit-c-v4",
-      "id": "esp32",
+      "id": "esp",
       "top": 0,
       "left": 0,
       "attrs": {}
     }
   ],
-  "connections": [],
+  "connections": [
+    [
+      "esp:TX",
+      "$serialMonitor:RX",
+      "",
+      []
+    ],
+    [
+      "esp:RX",
+      "$serialMonitor:TX",
+      "",
+      []
+    ]
+  ],
   "dependencies": {}
 }

--- a/examples/TestNTPClient/diagram.json
+++ b/examples/TestNTPClient/diagram.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "author": "aharshac",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-esp32-devkit-c-v4",
+      "id": "esp32",
+      "top": 0,
+      "left": 0,
+      "attrs": {}
+    }
+  ],
+  "connections": [],
+  "dependencies": {}
+}

--- a/examples/TestNTPClient/wokwi.toml
+++ b/examples/TestNTPClient/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = "build/TestNTPClient.ino.bin"
+elf     = "build/TestNTPClient.ino.elf"

--- a/examples/TestNTPClient/wokwi.toml
+++ b/examples/TestNTPClient/wokwi.toml
@@ -2,3 +2,4 @@
 version = 1
 firmware = "build/esp32.esp32.esp32/TestNTPClient.ino.bin"
 elf     = "build/esp32.esp32.esp32/TestNTPClient.ino.elf"
+rfc2217ServerPort = 4000

--- a/examples/TestNTPClient/wokwi.toml
+++ b/examples/TestNTPClient/wokwi.toml
@@ -1,4 +1,4 @@
 [wokwi]
 version = 1
-firmware = "build/TestNTPClient.ino.bin"
-elf     = "build/TestNTPClient.ino.elf"
+firmware = "build/esp32.esp32.esp32/TestNTPClient.ino.bin"
+elf     = "build/esp32.esp32.esp32/TestNTPClient.ino.elf"


### PR DESCRIPTION
## Changes

- Moved TestNTPClient for ESP32 out of the matrix to it's own build + simulate job.
- Handle watchdog in TestNTPClient.
- Added Wokwi config files.
- Add build folders in examples to .gitignore.
- Changed test name and source folder.